### PR TITLE
Any record type

### DIFF
--- a/bin/doh-cli
+++ b/bin/doh-cli
@@ -28,9 +28,7 @@ parser.add_argument(
     help="Choose DNS server: %s or provide your own url"%(','.join(url.keys()) ),
     default="libredns")
 parser.add_argument("domain", help="The Domain Name System to resolve")
-parser.add_argument(
-    "RR", help="Resourse Records: A, AAAA or CNAME",
-    choices=["A", "AAAA", "CNAME"], default="A")
+parser.add_argument("RR", nargs="?", help="Resourse Records: A, AAAA, CNAME, ext", default="A")
 args = parser.parse_args()
 
 jdns = []


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3138467/77839381-2b86e200-714a-11ea-9f45-e8c63a747ac8.png)

I'm not actually sure you'd want this done this way but I thought I'd make the PR anyway to get feedback. The downside is that this lets you use record types that are not real, but it gives a nice error message: **DNS resource record type is unknown.**

This change also makes it use A record as the default. That didn't actually work before.

Thoughts?
