### PR TITLE
Fix parsing problems introduced 3fbcf9775493608c1c79f1ca721e95754de26665

### DIFF
--- a/bin/doh-cli
+++ b/bin/doh-cli
@@ -24,7 +24,7 @@ url = {
 # second has a dot, swap the two arguments as the one with the dot
 # is obviously a domain
 try:
-    if '-' not in sys.argv[1] and len(sys.argv)<=3:
+    if '-' not in sys.argv[1] and len(sys.argv) == 3:
         if '.' in sys.argv[2]:
             swapme = sys.argv[2]
             sys.argv[2] = sys.argv[1]
@@ -41,7 +41,7 @@ parser.add_argument(
     "RR", help="Resourse Records: A, AAAA or CNAME",
     choices=["A", "AAAA", "CNAME", "MX", "NS", "SOA", "SPF", "SRV",
              "TXT", "CAA"],
-    default="A", nargs='?', type = lambda s : s.upper())
+    default="A", nargs='?', type=lambda s: s.upper())
 parser.add_argument(
     "--debug", help="show the entire response", action="store_true")
 parser.add_argument(

--- a/bin/doh-cli
+++ b/bin/doh-cli
@@ -20,12 +20,15 @@ url = {
     "cira-family":   "https://family.canadianshield.cira.ca/dns-query",
 }
 
+# if given only two cli arguments and the first doesn't have a '-' and the
+# second has a dot, swap the two arguments as the one with the dot
+# is obviously a domain
 try:
-    if '.' in sys.argv[2]:
-        swapme = sys.argv[2]
-        sys.argv[2] = sys.argv[1]
-        sys.argv[1] = swapme
-    sys.argv[2] = sys.argv[2].upper()
+    if '-' not in sys.argv[1] and len(sys.argv)<=3:
+        if '.' in sys.argv[2]:
+            swapme = sys.argv[2]
+            sys.argv[2] = sys.argv[1]
+            sys.argv[1] = swapme
 except IndexError:
     pass
 
@@ -38,7 +41,7 @@ parser.add_argument(
     "RR", help="Resourse Records: A, AAAA or CNAME",
     choices=["A", "AAAA", "CNAME", "MX", "NS", "SOA", "SPF", "SRV",
              "TXT", "CAA"],
-    default="A", nargs='?')
+    default="A", nargs='?', type = lambda s : s.upper())
 parser.add_argument(
     "--debug", help="show the entire response", action="store_true")
 parser.add_argument(


### PR DESCRIPTION
Commit 3fbcf9775493608c1c79f1ca721e95754de26665 introduced parsing
problems when handling cases like the following:
`doh-cli --time domain.tld`

This commit hopefully adds some safeguards around such problems.

It also changes capitalizing of RRs via a lambda within argparse parser
to ensure no other arguments are messed up accidentally.